### PR TITLE
[Update code generation] Fix issues identified by exercising the API

### DIFF
--- a/docs/CreateAssetRequest.md
+++ b/docs/CreateAssetRequest.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **input** | [**InputSettings**](InputSettings.md) |  | [optional] 
-**playback_policies** | [**list[PlaybackPolicy]**](PlaybackPolicy.md) |  | [optional] 
+**playback_policy** | [**list[PlaybackPolicy]**](PlaybackPolicy.md) |  | [optional] 
 **demo** | **bool** |  | [optional] 
 **per_title_encode** | **bool** |  | [optional] 
 **passthrough** | **str** |  | [optional] 

--- a/docs/CreateLiveStreamRequest.md
+++ b/docs/CreateLiveStreamRequest.md
@@ -3,8 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**policy** | [**PlaybackPolicy**](PlaybackPolicy.md) |  | [optional] 
-**new_asset_settings** | [**NewAssetSettings**](NewAssetSettings.md) |  | [optional] 
+**playback_policy** | [**list[PlaybackPolicy]**](PlaybackPolicy.md) |  | [optional] 
+**new_asset_settings** | [**CreateAssetRequest**](CreateAssetRequest.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/DirectUploadsApi.md
+++ b/docs/DirectUploadsApi.md
@@ -4,9 +4,9 @@ All URIs are relative to *https://api.mux.com*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**cancel_direct_upload**](DirectUploadsApi.md#cancel_direct_upload) | **PUT** /video/v1/uploads/{id}/cancel | Cancel a direct upload
+[**cancel_direct_upload**](DirectUploadsApi.md#cancel_direct_upload) | **PUT** /video/v1/uploads/{UPLOAD_ID}/cancel | Cancel a direct upload
 [**create_direct_upload**](DirectUploadsApi.md#create_direct_upload) | **POST** /video/v1/uploads | Create a new direct upload URL
-[**get_direct_upload**](DirectUploadsApi.md#get_direct_upload) | **GET** /video/v1/uploads/{id} | Retrieve a single direct upload&#39;s info
+[**get_direct_upload**](DirectUploadsApi.md#get_direct_upload) | **GET** /video/v1/uploads/{UPLOAD_ID} | Retrieve a single direct upload&#39;s info
 [**list_direct_uploads**](DirectUploadsApi.md#list_direct_uploads) | **GET** /video/v1/uploads | List direct uploads
 
 

--- a/docs/LiveStream.md
+++ b/docs/LiveStream.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **recent_asset_ids** | **list[str]** |  | [optional] 
 **status** | **str** |  | [optional] 
 **playback_ids** | [**list[PlaybackID]**](PlaybackID.md) |  | [optional] 
-**new_asset_settings** | [**NewAssetSettings**](NewAssetSettings.md) |  | [optional] 
+**new_asset_settings** | [**Asset**](Asset.md) |  | [optional] 
 **passthrough** | **str** |  | [optional] 
 **reconnect_window** | **float** |  | [optional] 
 

--- a/docs/LiveStreamsApi.md
+++ b/docs/LiveStreamsApi.md
@@ -5,9 +5,9 @@ All URIs are relative to *https://api.mux.com*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**create_live_stream**](LiveStreamsApi.md#create_live_stream) | **POST** /video/v1/live-streams | Create a live stream
-[**create_live_stream_playback_id**](LiveStreamsApi.md#create_live_stream_playback_id) | **POST** /video/v1/live-streams/{LIVE_KEY_ID}/playback-ids | Create a live stream playback ID
+[**create_live_stream_playback_id**](LiveStreamsApi.md#create_live_stream_playback_id) | **POST** /video/v1/live-streams/{LIVE_STREAM_ID}/playback-ids | Create a live stream playback ID
 [**delete_live_stream**](LiveStreamsApi.md#delete_live_stream) | **DELETE** /video/v1/live-streams/{LIVE_STREAM_ID} | Delete a live stream
-[**delete_live_stream_playback_id**](LiveStreamsApi.md#delete_live_stream_playback_id) | **DELETE** /video/v1/live-streams/{LIVE_KEY_ID}/playback-ids/{PLAYBACK_ID} | Delete a live stream playback ID
+[**delete_live_stream_playback_id**](LiveStreamsApi.md#delete_live_stream_playback_id) | **DELETE** /video/v1/live-streams/{LIVE_STREAM_ID}/playback-ids/{PLAYBACK_ID} | Delete a live stream playback ID
 [**get_live_stream**](LiveStreamsApi.md#get_live_stream) | **GET** /video/v1/live-streams/{LIVE_STREAM_ID} | Retrieve a live stream
 [**list_live_streams**](LiveStreamsApi.md#list_live_streams) | **GET** /video/v1/live-streams | List live streams
 [**reset_stream_key**](LiveStreamsApi.md#reset_stream_key) | **POST** /video/v1/live-streams/{LIVE_STREAM_ID}/reset-stream-key | Reset a live stream’s stream key

--- a/docs/Upload.md
+++ b/docs/Upload.md
@@ -3,9 +3,10 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**id** | **str** |  | [optional] 
 **timeout** | **int** | Max time in seconds for the signed upload URL to be valid. If a successful upload has not occurred before the timeout limit, the direct upload is marked &#x60;timed_out&#x60; | [optional] [default to 3600]
 **status** | **str** |  | [optional] 
-**new_asset_settings** | [**CreateAssetRequest**](CreateAssetRequest.md) |  | [optional] 
+**new_asset_settings** | [**Asset**](Asset.md) |  | [optional] 
 **asset_id** | **str** | Only set once the upload is in the &#x60;asset_created&#x60; state. | [optional] 
 **error** | [**UploadError**](UploadError.md) |  | [optional] 
 **cors_origin** | **str** | If the upload URL will be used in a browser, you must specify the origin in order for the signed URL to have the correct CORS headers. | [optional] 

--- a/mux_python/__init__.py
+++ b/mux_python/__init__.py
@@ -47,7 +47,6 @@ from mux_python.models.list_signing_keys_response import ListSigningKeysResponse
 from mux_python.models.list_uploads_response import ListUploadsResponse
 from mux_python.models.live_stream import LiveStream
 from mux_python.models.live_stream_response import LiveStreamResponse
-from mux_python.models.new_asset_settings import NewAssetSettings
 from mux_python.models.playback_id import PlaybackID
 from mux_python.models.playback_policy import PlaybackPolicy
 from mux_python.models.signal_live_stream_complete_response import SignalLiveStreamCompleteResponse

--- a/mux_python/api/direct_uploads_api.py
+++ b/mux_python/api/direct_uploads_api.py
@@ -104,7 +104,7 @@ class DirectUploadsApi(object):
         auth_settings = ['accessToken']  # noqa: E501
 
         return self.api_client.call_api(
-            '/video/v1/uploads/{id}/cancel', 'PUT',
+            '/video/v1/uploads/{UPLOAD_ID}/cancel', 'PUT',
             path_params,
             query_params,
             header_params,
@@ -296,7 +296,7 @@ class DirectUploadsApi(object):
         auth_settings = ['accessToken']  # noqa: E501
 
         return self.api_client.call_api(
-            '/video/v1/uploads/{id}', 'GET',
+            '/video/v1/uploads/{UPLOAD_ID}', 'GET',
             path_params,
             query_params,
             header_params,

--- a/mux_python/api/live_streams_api.py
+++ b/mux_python/api/live_streams_api.py
@@ -204,7 +204,7 @@ class LiveStreamsApi(object):
         auth_settings = ['accessToken']  # noqa: E501
 
         return self.api_client.call_api(
-            '/video/v1/live-streams/{LIVE_KEY_ID}/playback-ids', 'POST',
+            '/video/v1/live-streams/{LIVE_STREAM_ID}/playback-ids', 'POST',
             path_params,
             query_params,
             header_params,
@@ -392,7 +392,7 @@ class LiveStreamsApi(object):
         auth_settings = ['accessToken']  # noqa: E501
 
         return self.api_client.call_api(
-            '/video/v1/live-streams/{LIVE_KEY_ID}/playback-ids/{PLAYBACK_ID}', 'DELETE',
+            '/video/v1/live-streams/{LIVE_STREAM_ID}/playback-ids/{PLAYBACK_ID}', 'DELETE',
             path_params,
             query_params,
             header_params,

--- a/mux_python/models/__init__.py
+++ b/mux_python/models/__init__.py
@@ -35,7 +35,6 @@ from mux_python.models.list_signing_keys_response import ListSigningKeysResponse
 from mux_python.models.list_uploads_response import ListUploadsResponse
 from mux_python.models.live_stream import LiveStream
 from mux_python.models.live_stream_response import LiveStreamResponse
-from mux_python.models.new_asset_settings import NewAssetSettings
 from mux_python.models.playback_id import PlaybackID
 from mux_python.models.playback_policy import PlaybackPolicy
 from mux_python.models.signal_live_stream_complete_response import SignalLiveStreamCompleteResponse

--- a/mux_python/models/create_asset_request.py
+++ b/mux_python/models/create_asset_request.py
@@ -23,7 +23,7 @@ class CreateAssetRequest(object):
     """
     openapi_types = {
         'input': 'InputSettings',
-        'playback_policies': 'list[PlaybackPolicy]',
+        'playback_policy': 'list[PlaybackPolicy]',
         'demo': 'bool',
         'per_title_encode': 'bool',
         'passthrough': 'str',
@@ -32,18 +32,18 @@ class CreateAssetRequest(object):
 
     attribute_map = {
         'input': 'input',
-        'playback_policies': 'playback_policies',
+        'playback_policy': 'playback_policy',
         'demo': 'demo',
         'per_title_encode': 'per_title_encode',
         'passthrough': 'passthrough',
         'mp4_support': 'mp4_support'
     }
 
-    def __init__(self, input=None, playback_policies=None, demo=None, per_title_encode=None, passthrough=None, mp4_support=None):  # noqa: E501
+    def __init__(self, input=None, playback_policy=None, demo=None, per_title_encode=None, passthrough=None, mp4_support=None):  # noqa: E501
         """CreateAssetRequest - a model defined in OpenAPI"""  # noqa: E501
 
         self._input = None
-        self._playback_policies = None
+        self._playback_policy = None
         self._demo = None
         self._per_title_encode = None
         self._passthrough = None
@@ -52,8 +52,8 @@ class CreateAssetRequest(object):
 
         if input is not None:
             self.input = input
-        if playback_policies is not None:
-            self.playback_policies = playback_policies
+        if playback_policy is not None:
+            self.playback_policy = playback_policy
         if demo is not None:
             self.demo = demo
         if per_title_encode is not None:
@@ -85,25 +85,25 @@ class CreateAssetRequest(object):
         self._input = input
 
     @property
-    def playback_policies(self):
-        """Gets the playback_policies of this CreateAssetRequest.  # noqa: E501
+    def playback_policy(self):
+        """Gets the playback_policy of this CreateAssetRequest.  # noqa: E501
 
 
-        :return: The playback_policies of this CreateAssetRequest.  # noqa: E501
+        :return: The playback_policy of this CreateAssetRequest.  # noqa: E501
         :rtype: list[PlaybackPolicy]
         """
-        return self._playback_policies
+        return self._playback_policy
 
-    @playback_policies.setter
-    def playback_policies(self, playback_policies):
-        """Sets the playback_policies of this CreateAssetRequest.
+    @playback_policy.setter
+    def playback_policy(self, playback_policy):
+        """Sets the playback_policy of this CreateAssetRequest.
 
 
-        :param playback_policies: The playback_policies of this CreateAssetRequest.  # noqa: E501
+        :param playback_policy: The playback_policy of this CreateAssetRequest.  # noqa: E501
         :type: list[PlaybackPolicy]
         """
 
-        self._playback_policies = playback_policies
+        self._playback_policy = playback_policy
 
     @property
     def demo(self):

--- a/mux_python/models/create_live_stream_request.py
+++ b/mux_python/models/create_live_stream_request.py
@@ -22,47 +22,47 @@ class CreateLiveStreamRequest(object):
                             and the value is json key in definition.
     """
     openapi_types = {
-        'policy': 'PlaybackPolicy',
-        'new_asset_settings': 'NewAssetSettings'
+        'playback_policy': 'list[PlaybackPolicy]',
+        'new_asset_settings': 'CreateAssetRequest'
     }
 
     attribute_map = {
-        'policy': 'policy',
+        'playback_policy': 'playback_policy',
         'new_asset_settings': 'new_asset_settings'
     }
 
-    def __init__(self, policy=None, new_asset_settings=None):  # noqa: E501
+    def __init__(self, playback_policy=None, new_asset_settings=None):  # noqa: E501
         """CreateLiveStreamRequest - a model defined in OpenAPI"""  # noqa: E501
 
-        self._policy = None
+        self._playback_policy = None
         self._new_asset_settings = None
         self.discriminator = None
 
-        if policy is not None:
-            self.policy = policy
+        if playback_policy is not None:
+            self.playback_policy = playback_policy
         if new_asset_settings is not None:
             self.new_asset_settings = new_asset_settings
 
     @property
-    def policy(self):
-        """Gets the policy of this CreateLiveStreamRequest.  # noqa: E501
+    def playback_policy(self):
+        """Gets the playback_policy of this CreateLiveStreamRequest.  # noqa: E501
 
 
-        :return: The policy of this CreateLiveStreamRequest.  # noqa: E501
-        :rtype: PlaybackPolicy
+        :return: The playback_policy of this CreateLiveStreamRequest.  # noqa: E501
+        :rtype: list[PlaybackPolicy]
         """
-        return self._policy
+        return self._playback_policy
 
-    @policy.setter
-    def policy(self, policy):
-        """Sets the policy of this CreateLiveStreamRequest.
+    @playback_policy.setter
+    def playback_policy(self, playback_policy):
+        """Sets the playback_policy of this CreateLiveStreamRequest.
 
 
-        :param policy: The policy of this CreateLiveStreamRequest.  # noqa: E501
-        :type: PlaybackPolicy
+        :param playback_policy: The playback_policy of this CreateLiveStreamRequest.  # noqa: E501
+        :type: list[PlaybackPolicy]
         """
 
-        self._policy = policy
+        self._playback_policy = playback_policy
 
     @property
     def new_asset_settings(self):
@@ -70,7 +70,7 @@ class CreateLiveStreamRequest(object):
 
 
         :return: The new_asset_settings of this CreateLiveStreamRequest.  # noqa: E501
-        :rtype: NewAssetSettings
+        :rtype: CreateAssetRequest
         """
         return self._new_asset_settings
 
@@ -80,7 +80,7 @@ class CreateLiveStreamRequest(object):
 
 
         :param new_asset_settings: The new_asset_settings of this CreateLiveStreamRequest.  # noqa: E501
-        :type: NewAssetSettings
+        :type: CreateAssetRequest
         """
 
         self._new_asset_settings = new_asset_settings

--- a/mux_python/models/live_stream.py
+++ b/mux_python/models/live_stream.py
@@ -29,7 +29,7 @@ class LiveStream(object):
         'recent_asset_ids': 'list[str]',
         'status': 'str',
         'playback_ids': 'list[PlaybackID]',
-        'new_asset_settings': 'NewAssetSettings',
+        'new_asset_settings': 'Asset',
         'passthrough': 'str',
         'reconnect_window': 'float'
     }
@@ -236,7 +236,7 @@ class LiveStream(object):
 
 
         :return: The new_asset_settings of this LiveStream.  # noqa: E501
-        :rtype: NewAssetSettings
+        :rtype: Asset
         """
         return self._new_asset_settings
 
@@ -246,7 +246,7 @@ class LiveStream(object):
 
 
         :param new_asset_settings: The new_asset_settings of this LiveStream.  # noqa: E501
-        :type: NewAssetSettings
+        :type: Asset
         """
 
         self._new_asset_settings = new_asset_settings

--- a/mux_python/models/upload.py
+++ b/mux_python/models/upload.py
@@ -22,15 +22,17 @@ class Upload(object):
                             and the value is json key in definition.
     """
     openapi_types = {
+        'id': 'str',
         'timeout': 'int',
         'status': 'str',
-        'new_asset_settings': 'CreateAssetRequest',
+        'new_asset_settings': 'Asset',
         'asset_id': 'str',
         'error': 'UploadError',
         'cors_origin': 'str'
     }
 
     attribute_map = {
+        'id': 'id',
         'timeout': 'timeout',
         'status': 'status',
         'new_asset_settings': 'new_asset_settings',
@@ -39,9 +41,10 @@ class Upload(object):
         'cors_origin': 'cors_origin'
     }
 
-    def __init__(self, timeout=3600, status=None, new_asset_settings=None, asset_id=None, error=None, cors_origin=None):  # noqa: E501
+    def __init__(self, id=None, timeout=3600, status=None, new_asset_settings=None, asset_id=None, error=None, cors_origin=None):  # noqa: E501
         """Upload - a model defined in OpenAPI"""  # noqa: E501
 
+        self._id = None
         self._timeout = None
         self._status = None
         self._new_asset_settings = None
@@ -50,6 +53,8 @@ class Upload(object):
         self._cors_origin = None
         self.discriminator = None
 
+        if id is not None:
+            self.id = id
         if timeout is not None:
             self.timeout = timeout
         if status is not None:
@@ -62,6 +67,27 @@ class Upload(object):
             self.error = error
         if cors_origin is not None:
             self.cors_origin = cors_origin
+
+    @property
+    def id(self):
+        """Gets the id of this Upload.  # noqa: E501
+
+
+        :return: The id of this Upload.  # noqa: E501
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, id):
+        """Sets the id of this Upload.
+
+
+        :param id: The id of this Upload.  # noqa: E501
+        :type: str
+        """
+
+        self._id = id
 
     @property
     def timeout(self):
@@ -123,7 +149,7 @@ class Upload(object):
 
 
         :return: The new_asset_settings of this Upload.  # noqa: E501
-        :rtype: CreateAssetRequest
+        :rtype: Asset
         """
         return self._new_asset_settings
 
@@ -133,7 +159,7 @@ class Upload(object):
 
 
         :param new_asset_settings: The new_asset_settings of this Upload.  # noqa: E501
-        :type: CreateAssetRequest
+        :type: Asset
         """
 
         self._new_asset_settings = new_asset_settings


### PR DESCRIPTION
Code generated commit. Fixes a variety of issues identified by exercising the API. Specifically:

* Broken IDs on /live-streams
* Broken IDs in /uploads
Usage of playback_policy, policy, and playback_policies is now consistently "playback_policy", which is always list of strings
* Dropped NewAssetSettings. Now use CreateAssetRequest everywhere for the new_asset_settings param.