### PR TITLE
Fix print usage in ingest and non-existent-asset examples

### DIFF
--- a/examples/video/ingest.py
+++ b/examples/video/ingest.py
@@ -21,12 +21,12 @@ print("Created Asset ID: " + create_asset_response.data.id)
 # Wait for the asset to become ready, and then print its playback URL
 if create_asset_response.data.status != 'ready':
 
-    print "Waiting for asset to become ready..."
+    print("Waiting for asset to become ready...")
     while True:
         asset_response = assets_api.get_asset(create_asset_response.data.id)
         if asset_response.data.status != 'ready':
             print("Asset still not ready. Status was: " + asset_response.data.status)
             time.sleep(1)
         else:
-            print "Asset Ready! Playback URL: https://stream.mux.com/" + asset_response.data.playback_ids[0].id + ".m3u8"
+            print("Asset Ready! Playback URL: https://stream.mux.com/" + asset_response.data.playback_ids[0].id + ".m3u8")
             break

--- a/examples/video/none-existent-asset.py
+++ b/examples/video/none-existent-asset.py
@@ -15,6 +15,6 @@ assets_api = mux_python.AssetsApi(mux_python.ApiClient(configuration))
 try:
     assets_api.get_asset("HELLO")
 except NotFoundException as e:
-    print "Cound not find asset!"
-    print "Error Type: " + e.error_type
-    print "Error Messages: " + ", ".join(e.error_messages)
+    print("Cound not find asset!")
+    print("Error Type: " + e.error_type)
+    print("Error Messages: " + ", ".join(e.error_messages))


### PR DESCRIPTION
The following examples have a couple of lines where they mix the use of Python 2 syntax for `print` with Python 3:
* video/ingest.py
* video/none-existent-asset.py

This change allows the examples to be run directly in Python 3.