### PR TITLE
mux-python 1.9.0

### DIFF
--- a/docs/Asset.md
+++ b/docs/Asset.md
@@ -23,6 +23,8 @@ Name | Type | Description | Notes
 **mp4_support** | **str** |  | [optional] [default to 'none']
 **normalize_audio** | **bool** |  | [optional] [default to False]
 **static_renditions** | [**AssetStaticRenditions**](AssetStaticRenditions.md) |  | [optional] 
+**recording_times** | [**list[AssetRecordingTimes]**](AssetRecordingTimes.md) | An array of individual live stream recording sessions. A recording session is created on each encoder connection during the live stream | [optional] 
+**non_standard_input_reasons** | [**AssetNonStandardInputReasons**](AssetNonStandardInputReasons.md) |  | [optional] 
 **test** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/AssetNonStandardInputReasons.md
+++ b/docs/AssetNonStandardInputReasons.md
@@ -1,0 +1,18 @@
+# AssetNonStandardInputReasons
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**video_codec** | **str** | The video codec used on the input file | [optional] 
+**audio_codec** | **str** | The audio codec used on the input file | [optional] 
+**video_gop_size** | **str** | The video key frame Interval (also called as Group of Picture or GOP) of the input file | [optional] 
+**video_frame_rate** | **str** | The video frame rate of the input file | [optional] 
+**video_resolution** | **str** | The video resolution of the input file | [optional] 
+**pixel_aspect_ratio** | **str** | The video pixel aspect ratio of the input file | [optional] 
+**video_edit_list** | **str** | Video Edit List reason indicates that the input file&#39;s video track contains a complex Edit Decision List | [optional] 
+**audio_edit_list** | **str** | Audio Edit List reason indicates that the input file&#39;s audio track contains a complex Edit Decision List | [optional] 
+**unexpected_media_file_parameters** | **str** | A catch-all reason when the input file in created with non-standard encoding parameters | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/docs/AssetRecordingTimes.md
+++ b/docs/AssetRecordingTimes.md
@@ -1,0 +1,11 @@
+# AssetRecordingTimes
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**started_at** | **datetime** | The time at which the recording for the live stream started. The time value is Unix epoch time represented in ISO 8601 format | [optional] 
+**duration** | **float** | The duration of the live stream recorded. The time value is in seconds | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/docs/DisableLiveStreamResponse.md
+++ b/docs/DisableLiveStreamResponse.md
@@ -1,0 +1,10 @@
+# DisableLiveStreamResponse
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**data** | [**object**](.md) |  | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/docs/EnableLiveStreamResponse.md
+++ b/docs/EnableLiveStreamResponse.md
@@ -1,0 +1,10 @@
+# EnableLiveStreamResponse
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**data** | [**object**](.md) |  | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/docs/LiveStreamsApi.md
+++ b/docs/LiveStreamsApi.md
@@ -10,6 +10,8 @@ Method | HTTP request | Description
 [**delete_live_stream**](LiveStreamsApi.md#delete_live_stream) | **DELETE** /video/v1/live-streams/{LIVE_STREAM_ID} | Delete a live stream
 [**delete_live_stream_playback_id**](LiveStreamsApi.md#delete_live_stream_playback_id) | **DELETE** /video/v1/live-streams/{LIVE_STREAM_ID}/playback-ids/{PLAYBACK_ID} | Delete a live stream playback ID
 [**delete_live_stream_simulcast_target**](LiveStreamsApi.md#delete_live_stream_simulcast_target) | **DELETE** /video/v1/live-streams/{LIVE_STREAM_ID}/simulcast-targets/{SIMULCAST_TARGET_ID} | Delete a Live Stream Simulcast Target
+[**disable_live_stream**](LiveStreamsApi.md#disable_live_stream) | **PUT** /video/v1/live-streams/{LIVE_STREAM_ID}/disable | Disable a live stream
+[**enable_live_stream**](LiveStreamsApi.md#enable_live_stream) | **PUT** /video/v1/live-streams/{LIVE_STREAM_ID}/enable | Enable a live stream
 [**get_live_stream**](LiveStreamsApi.md#get_live_stream) | **GET** /video/v1/live-streams/{LIVE_STREAM_ID} | Retrieve a live stream
 [**get_live_stream_simulcast_target**](LiveStreamsApi.md#get_live_stream_simulcast_target) | **GET** /video/v1/live-streams/{LIVE_STREAM_ID}/simulcast-targets/{SIMULCAST_TARGET_ID} | Retrieve a Live Stream Simulcast Target
 [**list_live_streams**](LiveStreamsApi.md#list_live_streams) | **GET** /video/v1/live-streams | List live streams
@@ -335,6 +337,114 @@ void (empty response body)
 
  - **Content-Type**: Not defined
  - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **disable_live_stream**
+> DisableLiveStreamResponse disable_live_stream(live_stream_id)
+
+Disable a live stream
+
+Disables a live stream, making it reject incoming RTMP streams until re-enabled.
+
+### Example
+
+* Basic Authentication (accessToken): 
+```python
+from __future__ import print_function
+import time
+import mux_python
+from mux_python.rest import ApiException
+from pprint import pprint
+configuration = mux_python.Configuration()
+# Configure HTTP basic authorization: accessToken
+configuration.username = 'YOUR_USERNAME'
+configuration.password = 'YOUR_PASSWORD'
+
+# create an instance of the API class
+api_instance = mux_python.LiveStreamsApi(mux_python.ApiClient(configuration))
+live_stream_id = 'live_stream_id_example' # str | The live stream ID
+
+try:
+    # Disable a live stream
+    api_response = api_instance.disable_live_stream(live_stream_id)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling LiveStreamsApi->disable_live_stream: %s\n" % e)
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **live_stream_id** | **str**| The live stream ID | 
+
+### Return type
+
+[**DisableLiveStreamResponse**](DisableLiveStreamResponse.md)
+
+### Authorization
+
+[accessToken](../README.md#accessToken)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **enable_live_stream**
+> EnableLiveStreamResponse enable_live_stream(live_stream_id)
+
+Enable a live stream
+
+Enables a live stream, allowing it to accept an incoming RTMP stream.
+
+### Example
+
+* Basic Authentication (accessToken): 
+```python
+from __future__ import print_function
+import time
+import mux_python
+from mux_python.rest import ApiException
+from pprint import pprint
+configuration = mux_python.Configuration()
+# Configure HTTP basic authorization: accessToken
+configuration.username = 'YOUR_USERNAME'
+configuration.password = 'YOUR_PASSWORD'
+
+# create an instance of the API class
+api_instance = mux_python.LiveStreamsApi(mux_python.ApiClient(configuration))
+live_stream_id = 'live_stream_id_example' # str | The live stream ID
+
+try:
+    # Enable a live stream
+    api_response = api_instance.enable_live_stream(live_stream_id)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling LiveStreamsApi->enable_live_stream: %s\n" % e)
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **live_stream_id** | **str**| The live stream ID | 
+
+### Return type
+
+[**EnableLiveStreamResponse**](EnableLiveStreamResponse.md)
+
+### Authorization
+
+[accessToken](../README.md#accessToken)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/examples/video/exercise-live-streams.py
+++ b/examples/video/exercise-live-streams.py
@@ -100,6 +100,26 @@ except ApiException as e:
     sys.exit(1)
 print("signal-live-stream-complete OK ✅")
 
+# ========== disable-live-stream ==========
+try:
+    live_api.disable_live_stream(create_live_stream_response.data.id)
+except ApiException as e:
+    print("Should not have errored when disabling live stream ❌ ")
+    sys.exit(1)
+disabled_live_stream = live_api.get_live_stream(create_live_stream_response.data.id)
+assert disabled_live_stream.data.status == 'disabled'
+print("disable-live-stream OK ✅")
+
+# ========== enable-live-stream ==========
+try:
+    live_api.enable_live_stream(create_live_stream_response.data.id)
+except ApiException as e:
+    print("Should not have errored when enabling live stream ❌ ")
+    sys.exit(1)
+enabled_live_stream = live_api.get_live_stream(create_live_stream_response.data.id)
+assert enabled_live_stream.data.status == 'idle'
+print("enable-live-stream OK ✅")
+
 # ========== delete-live-stream ==========
 live_api.delete_live_stream(create_live_stream_response.data.id)
 logger.print_debug("Deleted Live Stream (void response) ")

--- a/mux_python/__init__.py
+++ b/mux_python/__init__.py
@@ -11,7 +11,7 @@ NOTE: This class is auto generated. Do not edit the class manually.
 
 from __future__ import absolute_import
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 
 # import apis into sdk package
 from mux_python.api.assets_api import AssetsApi
@@ -35,6 +35,8 @@ from mux_python.models.abridged_video_view import AbridgedVideoView
 from mux_python.models.asset import Asset
 from mux_python.models.asset_errors import AssetErrors
 from mux_python.models.asset_master import AssetMaster
+from mux_python.models.asset_non_standard_input_reasons import AssetNonStandardInputReasons
+from mux_python.models.asset_recording_times import AssetRecordingTimes
 from mux_python.models.asset_response import AssetResponse
 from mux_python.models.asset_static_renditions import AssetStaticRenditions
 from mux_python.models.asset_static_renditions_files import AssetStaticRenditionsFiles
@@ -48,6 +50,8 @@ from mux_python.models.create_track_request import CreateTrackRequest
 from mux_python.models.create_track_response import CreateTrackResponse
 from mux_python.models.create_upload_request import CreateUploadRequest
 from mux_python.models.delivery_report import DeliveryReport
+from mux_python.models.disable_live_stream_response import DisableLiveStreamResponse
+from mux_python.models.enable_live_stream_response import EnableLiveStreamResponse
 from mux_python.models.error import Error
 from mux_python.models.filter_value import FilterValue
 from mux_python.models.get_asset_input_info_response import GetAssetInputInfoResponse

--- a/mux_python/api/live_streams_api.py
+++ b/mux_python/api/live_streams_api.py
@@ -623,6 +623,198 @@ class LiveStreamsApi(object):
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats)
 
+    def disable_live_stream(self, live_stream_id, **kwargs):  # noqa: E501
+        """Disable a live stream  # noqa: E501
+
+        Disables a live stream, making it reject incoming RTMP streams until re-enabled.  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.disable_live_stream(live_stream_id, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :param str live_stream_id: The live stream ID (required)
+        :return: DisableLiveStreamResponse
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async_req'):
+            return self.disable_live_stream_with_http_info(live_stream_id, **kwargs)  # noqa: E501
+        else:
+            (data) = self.disable_live_stream_with_http_info(live_stream_id, **kwargs)  # noqa: E501
+            return data
+
+    def disable_live_stream_with_http_info(self, live_stream_id, **kwargs):  # noqa: E501
+        """Disable a live stream  # noqa: E501
+
+        Disables a live stream, making it reject incoming RTMP streams until re-enabled.  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.disable_live_stream_with_http_info(live_stream_id, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :param str live_stream_id: The live stream ID (required)
+        :return: DisableLiveStreamResponse
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        local_var_params = locals()
+
+        all_params = ['live_stream_id']  # noqa: E501
+        all_params.append('async_req')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        for key, val in six.iteritems(local_var_params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method disable_live_stream" % key
+                )
+            local_var_params[key] = val
+        del local_var_params['kwargs']
+        # verify the required parameter 'live_stream_id' is set
+        if ('live_stream_id' not in local_var_params or
+                local_var_params['live_stream_id'] is None):
+            raise ValueError("Missing the required parameter `live_stream_id` when calling `disable_live_stream`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+        if 'live_stream_id' in local_var_params:
+            path_params['LIVE_STREAM_ID'] = local_var_params['live_stream_id']  # noqa: E501
+
+        query_params = []
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = ['accessToken']  # noqa: E501
+
+        return self.api_client.call_api(
+            '/video/v1/live-streams/{LIVE_STREAM_ID}/disable', 'PUT',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='DisableLiveStreamResponse',  # noqa: E501
+            auth_settings=auth_settings,
+            async_req=local_var_params.get('async_req'),
+            _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=local_var_params.get('_preload_content', True),
+            _request_timeout=local_var_params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
+    def enable_live_stream(self, live_stream_id, **kwargs):  # noqa: E501
+        """Enable a live stream  # noqa: E501
+
+        Enables a live stream, allowing it to accept an incoming RTMP stream.  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.enable_live_stream(live_stream_id, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :param str live_stream_id: The live stream ID (required)
+        :return: EnableLiveStreamResponse
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async_req'):
+            return self.enable_live_stream_with_http_info(live_stream_id, **kwargs)  # noqa: E501
+        else:
+            (data) = self.enable_live_stream_with_http_info(live_stream_id, **kwargs)  # noqa: E501
+            return data
+
+    def enable_live_stream_with_http_info(self, live_stream_id, **kwargs):  # noqa: E501
+        """Enable a live stream  # noqa: E501
+
+        Enables a live stream, allowing it to accept an incoming RTMP stream.  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.enable_live_stream_with_http_info(live_stream_id, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :param str live_stream_id: The live stream ID (required)
+        :return: EnableLiveStreamResponse
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        local_var_params = locals()
+
+        all_params = ['live_stream_id']  # noqa: E501
+        all_params.append('async_req')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        for key, val in six.iteritems(local_var_params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method enable_live_stream" % key
+                )
+            local_var_params[key] = val
+        del local_var_params['kwargs']
+        # verify the required parameter 'live_stream_id' is set
+        if ('live_stream_id' not in local_var_params or
+                local_var_params['live_stream_id'] is None):
+            raise ValueError("Missing the required parameter `live_stream_id` when calling `enable_live_stream`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+        if 'live_stream_id' in local_var_params:
+            path_params['LIVE_STREAM_ID'] = local_var_params['live_stream_id']  # noqa: E501
+
+        query_params = []
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = ['accessToken']  # noqa: E501
+
+        return self.api_client.call_api(
+            '/video/v1/live-streams/{LIVE_STREAM_ID}/enable', 'PUT',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='EnableLiveStreamResponse',  # noqa: E501
+            auth_settings=auth_settings,
+            async_req=local_var_params.get('async_req'),
+            _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=local_var_params.get('_preload_content', True),
+            _request_timeout=local_var_params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def get_live_stream(self, live_stream_id, **kwargs):  # noqa: E501
         """Retrieve a live stream  # noqa: E501
 

--- a/mux_python/api_client.py
+++ b/mux_python/api_client.py
@@ -72,7 +72,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'Mux Python | 1.8.0'
+        self.user_agent = 'Mux Python | 1.9.0'
 
     def __del__(self):
         if self._pool:

--- a/mux_python/configuration.py
+++ b/mux_python/configuration.py
@@ -228,5 +228,5 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: v1\n"\
-               "SDK Package Version: 1.8.0".\
+               "SDK Package Version: 1.9.0".\
                format(env=sys.platform, pyversion=sys.version)

--- a/mux_python/models/__init__.py
+++ b/mux_python/models/__init__.py
@@ -15,6 +15,8 @@ from mux_python.models.abridged_video_view import AbridgedVideoView
 from mux_python.models.asset import Asset
 from mux_python.models.asset_errors import AssetErrors
 from mux_python.models.asset_master import AssetMaster
+from mux_python.models.asset_non_standard_input_reasons import AssetNonStandardInputReasons
+from mux_python.models.asset_recording_times import AssetRecordingTimes
 from mux_python.models.asset_response import AssetResponse
 from mux_python.models.asset_static_renditions import AssetStaticRenditions
 from mux_python.models.asset_static_renditions_files import AssetStaticRenditionsFiles
@@ -28,6 +30,8 @@ from mux_python.models.create_track_request import CreateTrackRequest
 from mux_python.models.create_track_response import CreateTrackResponse
 from mux_python.models.create_upload_request import CreateUploadRequest
 from mux_python.models.delivery_report import DeliveryReport
+from mux_python.models.disable_live_stream_response import DisableLiveStreamResponse
+from mux_python.models.enable_live_stream_response import EnableLiveStreamResponse
 from mux_python.models.error import Error
 from mux_python.models.filter_value import FilterValue
 from mux_python.models.get_asset_input_info_response import GetAssetInputInfoResponse

--- a/mux_python/models/asset.py
+++ b/mux_python/models/asset.py
@@ -42,6 +42,8 @@ class Asset(object):
         'mp4_support': 'str',
         'normalize_audio': 'bool',
         'static_renditions': 'AssetStaticRenditions',
+        'recording_times': 'list[AssetRecordingTimes]',
+        'non_standard_input_reasons': 'AssetNonStandardInputReasons',
         'test': 'bool'
     }
 
@@ -66,10 +68,12 @@ class Asset(object):
         'mp4_support': 'mp4_support',
         'normalize_audio': 'normalize_audio',
         'static_renditions': 'static_renditions',
+        'recording_times': 'recording_times',
+        'non_standard_input_reasons': 'non_standard_input_reasons',
         'test': 'test'
     }
 
-    def __init__(self, id=None, created_at=None, deleted_at=None, status=None, duration=None, max_stored_resolution=None, max_stored_frame_rate=None, aspect_ratio=None, playback_ids=None, tracks=None, errors=None, per_title_encode=None, is_live=None, passthrough=None, live_stream_id=None, master=None, master_access='none', mp4_support='none', normalize_audio=False, static_renditions=None, test=None):  # noqa: E501
+    def __init__(self, id=None, created_at=None, deleted_at=None, status=None, duration=None, max_stored_resolution=None, max_stored_frame_rate=None, aspect_ratio=None, playback_ids=None, tracks=None, errors=None, per_title_encode=None, is_live=None, passthrough=None, live_stream_id=None, master=None, master_access='none', mp4_support='none', normalize_audio=False, static_renditions=None, recording_times=None, non_standard_input_reasons=None, test=None):  # noqa: E501
         """Asset - a model defined in OpenAPI"""  # noqa: E501
 
         self._id = None
@@ -92,6 +96,8 @@ class Asset(object):
         self._mp4_support = None
         self._normalize_audio = None
         self._static_renditions = None
+        self._recording_times = None
+        self._non_standard_input_reasons = None
         self._test = None
         self.discriminator = None
 
@@ -135,6 +141,10 @@ class Asset(object):
             self.normalize_audio = normalize_audio
         if static_renditions is not None:
             self.static_renditions = static_renditions
+        if recording_times is not None:
+            self.recording_times = recording_times
+        if non_standard_input_reasons is not None:
+            self.non_standard_input_reasons = non_standard_input_reasons
         if test is not None:
             self.test = test
 
@@ -569,6 +579,50 @@ class Asset(object):
         """
 
         self._static_renditions = static_renditions
+
+    @property
+    def recording_times(self):
+        """Gets the recording_times of this Asset.  # noqa: E501
+
+        An array of individual live stream recording sessions. A recording session is created on each encoder connection during the live stream  # noqa: E501
+
+        :return: The recording_times of this Asset.  # noqa: E501
+        :rtype: list[AssetRecordingTimes]
+        """
+        return self._recording_times
+
+    @recording_times.setter
+    def recording_times(self, recording_times):
+        """Sets the recording_times of this Asset.
+
+        An array of individual live stream recording sessions. A recording session is created on each encoder connection during the live stream  # noqa: E501
+
+        :param recording_times: The recording_times of this Asset.  # noqa: E501
+        :type: list[AssetRecordingTimes]
+        """
+
+        self._recording_times = recording_times
+
+    @property
+    def non_standard_input_reasons(self):
+        """Gets the non_standard_input_reasons of this Asset.  # noqa: E501
+
+
+        :return: The non_standard_input_reasons of this Asset.  # noqa: E501
+        :rtype: AssetNonStandardInputReasons
+        """
+        return self._non_standard_input_reasons
+
+    @non_standard_input_reasons.setter
+    def non_standard_input_reasons(self, non_standard_input_reasons):
+        """Sets the non_standard_input_reasons of this Asset.
+
+
+        :param non_standard_input_reasons: The non_standard_input_reasons of this Asset.  # noqa: E501
+        :type: AssetNonStandardInputReasons
+        """
+
+        self._non_standard_input_reasons = non_standard_input_reasons
 
     @property
     def test(self):

--- a/mux_python/models/asset_non_standard_input_reasons.py
+++ b/mux_python/models/asset_non_standard_input_reasons.py
@@ -1,0 +1,353 @@
+# coding: utf-8
+
+"""
+Mux Python - Copyright 2019 Mux Inc.
+
+NOTE: This class is auto generated. Do not edit the class manually.
+"""
+
+
+import pprint
+import re  # noqa: F401
+import six
+
+class AssetNonStandardInputReasons(object):
+
+
+    """
+    Attributes:
+      openapi_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    openapi_types = {
+        'video_codec': 'str',
+        'audio_codec': 'str',
+        'video_gop_size': 'str',
+        'video_frame_rate': 'str',
+        'video_resolution': 'str',
+        'pixel_aspect_ratio': 'str',
+        'video_edit_list': 'str',
+        'audio_edit_list': 'str',
+        'unexpected_media_file_parameters': 'str'
+    }
+
+    attribute_map = {
+        'video_codec': 'video_codec',
+        'audio_codec': 'audio_codec',
+        'video_gop_size': 'video_gop_size',
+        'video_frame_rate': 'video_frame_rate',
+        'video_resolution': 'video_resolution',
+        'pixel_aspect_ratio': 'pixel_aspect_ratio',
+        'video_edit_list': 'video_edit_list',
+        'audio_edit_list': 'audio_edit_list',
+        'unexpected_media_file_parameters': 'unexpected_media_file_parameters'
+    }
+
+    def __init__(self, video_codec=None, audio_codec=None, video_gop_size=None, video_frame_rate=None, video_resolution=None, pixel_aspect_ratio=None, video_edit_list=None, audio_edit_list=None, unexpected_media_file_parameters=None):  # noqa: E501
+        """AssetNonStandardInputReasons - a model defined in OpenAPI"""  # noqa: E501
+
+        self._video_codec = None
+        self._audio_codec = None
+        self._video_gop_size = None
+        self._video_frame_rate = None
+        self._video_resolution = None
+        self._pixel_aspect_ratio = None
+        self._video_edit_list = None
+        self._audio_edit_list = None
+        self._unexpected_media_file_parameters = None
+        self.discriminator = None
+
+        if video_codec is not None:
+            self.video_codec = video_codec
+        if audio_codec is not None:
+            self.audio_codec = audio_codec
+        if video_gop_size is not None:
+            self.video_gop_size = video_gop_size
+        if video_frame_rate is not None:
+            self.video_frame_rate = video_frame_rate
+        if video_resolution is not None:
+            self.video_resolution = video_resolution
+        if pixel_aspect_ratio is not None:
+            self.pixel_aspect_ratio = pixel_aspect_ratio
+        if video_edit_list is not None:
+            self.video_edit_list = video_edit_list
+        if audio_edit_list is not None:
+            self.audio_edit_list = audio_edit_list
+        if unexpected_media_file_parameters is not None:
+            self.unexpected_media_file_parameters = unexpected_media_file_parameters
+
+    @property
+    def video_codec(self):
+        """Gets the video_codec of this AssetNonStandardInputReasons.  # noqa: E501
+
+        The video codec used on the input file  # noqa: E501
+
+        :return: The video_codec of this AssetNonStandardInputReasons.  # noqa: E501
+        :rtype: str
+        """
+        return self._video_codec
+
+    @video_codec.setter
+    def video_codec(self, video_codec):
+        """Sets the video_codec of this AssetNonStandardInputReasons.
+
+        The video codec used on the input file  # noqa: E501
+
+        :param video_codec: The video_codec of this AssetNonStandardInputReasons.  # noqa: E501
+        :type: str
+        """
+
+        self._video_codec = video_codec
+
+    @property
+    def audio_codec(self):
+        """Gets the audio_codec of this AssetNonStandardInputReasons.  # noqa: E501
+
+        The audio codec used on the input file  # noqa: E501
+
+        :return: The audio_codec of this AssetNonStandardInputReasons.  # noqa: E501
+        :rtype: str
+        """
+        return self._audio_codec
+
+    @audio_codec.setter
+    def audio_codec(self, audio_codec):
+        """Sets the audio_codec of this AssetNonStandardInputReasons.
+
+        The audio codec used on the input file  # noqa: E501
+
+        :param audio_codec: The audio_codec of this AssetNonStandardInputReasons.  # noqa: E501
+        :type: str
+        """
+
+        self._audio_codec = audio_codec
+
+    @property
+    def video_gop_size(self):
+        """Gets the video_gop_size of this AssetNonStandardInputReasons.  # noqa: E501
+
+        The video key frame Interval (also called as Group of Picture or GOP) of the input file  # noqa: E501
+
+        :return: The video_gop_size of this AssetNonStandardInputReasons.  # noqa: E501
+        :rtype: str
+        """
+        return self._video_gop_size
+
+    @video_gop_size.setter
+    def video_gop_size(self, video_gop_size):
+        """Sets the video_gop_size of this AssetNonStandardInputReasons.
+
+        The video key frame Interval (also called as Group of Picture or GOP) of the input file  # noqa: E501
+
+        :param video_gop_size: The video_gop_size of this AssetNonStandardInputReasons.  # noqa: E501
+        :type: str
+        """
+        allowed_values = ["high"]  # noqa: E501
+        if video_gop_size not in allowed_values:
+            raise ValueError(
+                "Invalid value for `video_gop_size` ({0}), must be one of {1}"  # noqa: E501
+                .format(video_gop_size, allowed_values)
+            )
+
+        self._video_gop_size = video_gop_size
+
+    @property
+    def video_frame_rate(self):
+        """Gets the video_frame_rate of this AssetNonStandardInputReasons.  # noqa: E501
+
+        The video frame rate of the input file  # noqa: E501
+
+        :return: The video_frame_rate of this AssetNonStandardInputReasons.  # noqa: E501
+        :rtype: str
+        """
+        return self._video_frame_rate
+
+    @video_frame_rate.setter
+    def video_frame_rate(self, video_frame_rate):
+        """Sets the video_frame_rate of this AssetNonStandardInputReasons.
+
+        The video frame rate of the input file  # noqa: E501
+
+        :param video_frame_rate: The video_frame_rate of this AssetNonStandardInputReasons.  # noqa: E501
+        :type: str
+        """
+
+        self._video_frame_rate = video_frame_rate
+
+    @property
+    def video_resolution(self):
+        """Gets the video_resolution of this AssetNonStandardInputReasons.  # noqa: E501
+
+        The video resolution of the input file  # noqa: E501
+
+        :return: The video_resolution of this AssetNonStandardInputReasons.  # noqa: E501
+        :rtype: str
+        """
+        return self._video_resolution
+
+    @video_resolution.setter
+    def video_resolution(self, video_resolution):
+        """Sets the video_resolution of this AssetNonStandardInputReasons.
+
+        The video resolution of the input file  # noqa: E501
+
+        :param video_resolution: The video_resolution of this AssetNonStandardInputReasons.  # noqa: E501
+        :type: str
+        """
+
+        self._video_resolution = video_resolution
+
+    @property
+    def pixel_aspect_ratio(self):
+        """Gets the pixel_aspect_ratio of this AssetNonStandardInputReasons.  # noqa: E501
+
+        The video pixel aspect ratio of the input file  # noqa: E501
+
+        :return: The pixel_aspect_ratio of this AssetNonStandardInputReasons.  # noqa: E501
+        :rtype: str
+        """
+        return self._pixel_aspect_ratio
+
+    @pixel_aspect_ratio.setter
+    def pixel_aspect_ratio(self, pixel_aspect_ratio):
+        """Sets the pixel_aspect_ratio of this AssetNonStandardInputReasons.
+
+        The video pixel aspect ratio of the input file  # noqa: E501
+
+        :param pixel_aspect_ratio: The pixel_aspect_ratio of this AssetNonStandardInputReasons.  # noqa: E501
+        :type: str
+        """
+
+        self._pixel_aspect_ratio = pixel_aspect_ratio
+
+    @property
+    def video_edit_list(self):
+        """Gets the video_edit_list of this AssetNonStandardInputReasons.  # noqa: E501
+
+        Video Edit List reason indicates that the input file's video track contains a complex Edit Decision List  # noqa: E501
+
+        :return: The video_edit_list of this AssetNonStandardInputReasons.  # noqa: E501
+        :rtype: str
+        """
+        return self._video_edit_list
+
+    @video_edit_list.setter
+    def video_edit_list(self, video_edit_list):
+        """Sets the video_edit_list of this AssetNonStandardInputReasons.
+
+        Video Edit List reason indicates that the input file's video track contains a complex Edit Decision List  # noqa: E501
+
+        :param video_edit_list: The video_edit_list of this AssetNonStandardInputReasons.  # noqa: E501
+        :type: str
+        """
+        allowed_values = ["non-standard"]  # noqa: E501
+        if video_edit_list not in allowed_values:
+            raise ValueError(
+                "Invalid value for `video_edit_list` ({0}), must be one of {1}"  # noqa: E501
+                .format(video_edit_list, allowed_values)
+            )
+
+        self._video_edit_list = video_edit_list
+
+    @property
+    def audio_edit_list(self):
+        """Gets the audio_edit_list of this AssetNonStandardInputReasons.  # noqa: E501
+
+        Audio Edit List reason indicates that the input file's audio track contains a complex Edit Decision List  # noqa: E501
+
+        :return: The audio_edit_list of this AssetNonStandardInputReasons.  # noqa: E501
+        :rtype: str
+        """
+        return self._audio_edit_list
+
+    @audio_edit_list.setter
+    def audio_edit_list(self, audio_edit_list):
+        """Sets the audio_edit_list of this AssetNonStandardInputReasons.
+
+        Audio Edit List reason indicates that the input file's audio track contains a complex Edit Decision List  # noqa: E501
+
+        :param audio_edit_list: The audio_edit_list of this AssetNonStandardInputReasons.  # noqa: E501
+        :type: str
+        """
+        allowed_values = ["non-standard"]  # noqa: E501
+        if audio_edit_list not in allowed_values:
+            raise ValueError(
+                "Invalid value for `audio_edit_list` ({0}), must be one of {1}"  # noqa: E501
+                .format(audio_edit_list, allowed_values)
+            )
+
+        self._audio_edit_list = audio_edit_list
+
+    @property
+    def unexpected_media_file_parameters(self):
+        """Gets the unexpected_media_file_parameters of this AssetNonStandardInputReasons.  # noqa: E501
+
+        A catch-all reason when the input file in created with non-standard encoding parameters  # noqa: E501
+
+        :return: The unexpected_media_file_parameters of this AssetNonStandardInputReasons.  # noqa: E501
+        :rtype: str
+        """
+        return self._unexpected_media_file_parameters
+
+    @unexpected_media_file_parameters.setter
+    def unexpected_media_file_parameters(self, unexpected_media_file_parameters):
+        """Sets the unexpected_media_file_parameters of this AssetNonStandardInputReasons.
+
+        A catch-all reason when the input file in created with non-standard encoding parameters  # noqa: E501
+
+        :param unexpected_media_file_parameters: The unexpected_media_file_parameters of this AssetNonStandardInputReasons.  # noqa: E501
+        :type: str
+        """
+        allowed_values = ["non-standard"]  # noqa: E501
+        if unexpected_media_file_parameters not in allowed_values:
+            raise ValueError(
+                "Invalid value for `unexpected_media_file_parameters` ({0}), must be one of {1}"  # noqa: E501
+                .format(unexpected_media_file_parameters, allowed_values)
+            )
+
+        self._unexpected_media_file_parameters = unexpected_media_file_parameters
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.openapi_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, AssetNonStandardInputReasons):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other

--- a/mux_python/models/asset_recording_times.py
+++ b/mux_python/models/asset_recording_times.py
@@ -1,0 +1,133 @@
+# coding: utf-8
+
+"""
+Mux Python - Copyright 2019 Mux Inc.
+
+NOTE: This class is auto generated. Do not edit the class manually.
+"""
+
+
+import pprint
+import re  # noqa: F401
+import six
+
+class AssetRecordingTimes(object):
+
+
+    """
+    Attributes:
+      openapi_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    openapi_types = {
+        'started_at': 'datetime',
+        'duration': 'float'
+    }
+
+    attribute_map = {
+        'started_at': 'started_at',
+        'duration': 'duration'
+    }
+
+    def __init__(self, started_at=None, duration=None):  # noqa: E501
+        """AssetRecordingTimes - a model defined in OpenAPI"""  # noqa: E501
+
+        self._started_at = None
+        self._duration = None
+        self.discriminator = None
+
+        if started_at is not None:
+            self.started_at = started_at
+        if duration is not None:
+            self.duration = duration
+
+    @property
+    def started_at(self):
+        """Gets the started_at of this AssetRecordingTimes.  # noqa: E501
+
+        The time at which the recording for the live stream started. The time value is Unix epoch time represented in ISO 8601 format  # noqa: E501
+
+        :return: The started_at of this AssetRecordingTimes.  # noqa: E501
+        :rtype: datetime
+        """
+        return self._started_at
+
+    @started_at.setter
+    def started_at(self, started_at):
+        """Sets the started_at of this AssetRecordingTimes.
+
+        The time at which the recording for the live stream started. The time value is Unix epoch time represented in ISO 8601 format  # noqa: E501
+
+        :param started_at: The started_at of this AssetRecordingTimes.  # noqa: E501
+        :type: datetime
+        """
+
+        self._started_at = started_at
+
+    @property
+    def duration(self):
+        """Gets the duration of this AssetRecordingTimes.  # noqa: E501
+
+        The duration of the live stream recorded. The time value is in seconds  # noqa: E501
+
+        :return: The duration of this AssetRecordingTimes.  # noqa: E501
+        :rtype: float
+        """
+        return self._duration
+
+    @duration.setter
+    def duration(self, duration):
+        """Sets the duration of this AssetRecordingTimes.
+
+        The duration of the live stream recorded. The time value is in seconds  # noqa: E501
+
+        :param duration: The duration of this AssetRecordingTimes.  # noqa: E501
+        :type: float
+        """
+
+        self._duration = duration
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.openapi_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, AssetRecordingTimes):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other

--- a/mux_python/models/disable_live_stream_response.py
+++ b/mux_python/models/disable_live_stream_response.py
@@ -1,0 +1,103 @@
+# coding: utf-8
+
+"""
+Mux Python - Copyright 2019 Mux Inc.
+
+NOTE: This class is auto generated. Do not edit the class manually.
+"""
+
+
+import pprint
+import re  # noqa: F401
+import six
+
+class DisableLiveStreamResponse(object):
+
+
+    """
+    Attributes:
+      openapi_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    openapi_types = {
+        'data': 'object'
+    }
+
+    attribute_map = {
+        'data': 'data'
+    }
+
+    def __init__(self, data=None):  # noqa: E501
+        """DisableLiveStreamResponse - a model defined in OpenAPI"""  # noqa: E501
+
+        self._data = None
+        self.discriminator = None
+
+        if data is not None:
+            self.data = data
+
+    @property
+    def data(self):
+        """Gets the data of this DisableLiveStreamResponse.  # noqa: E501
+
+
+        :return: The data of this DisableLiveStreamResponse.  # noqa: E501
+        :rtype: object
+        """
+        return self._data
+
+    @data.setter
+    def data(self, data):
+        """Sets the data of this DisableLiveStreamResponse.
+
+
+        :param data: The data of this DisableLiveStreamResponse.  # noqa: E501
+        :type: object
+        """
+
+        self._data = data
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.openapi_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, DisableLiveStreamResponse):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other

--- a/mux_python/models/enable_live_stream_response.py
+++ b/mux_python/models/enable_live_stream_response.py
@@ -1,0 +1,103 @@
+# coding: utf-8
+
+"""
+Mux Python - Copyright 2019 Mux Inc.
+
+NOTE: This class is auto generated. Do not edit the class manually.
+"""
+
+
+import pprint
+import re  # noqa: F401
+import six
+
+class EnableLiveStreamResponse(object):
+
+
+    """
+    Attributes:
+      openapi_types (dict): The key is attribute name
+                            and the value is attribute type.
+      attribute_map (dict): The key is attribute name
+                            and the value is json key in definition.
+    """
+    openapi_types = {
+        'data': 'object'
+    }
+
+    attribute_map = {
+        'data': 'data'
+    }
+
+    def __init__(self, data=None):  # noqa: E501
+        """EnableLiveStreamResponse - a model defined in OpenAPI"""  # noqa: E501
+
+        self._data = None
+        self.discriminator = None
+
+        if data is not None:
+            self.data = data
+
+    @property
+    def data(self):
+        """Gets the data of this EnableLiveStreamResponse.  # noqa: E501
+
+
+        :return: The data of this EnableLiveStreamResponse.  # noqa: E501
+        :rtype: object
+        """
+        return self._data
+
+    @data.setter
+    def data(self, data):
+        """Sets the data of this EnableLiveStreamResponse.
+
+
+        :param data: The data of this EnableLiveStreamResponse.  # noqa: E501
+        :type: object
+        """
+
+        self._data = data
+
+    def to_dict(self):
+        """Returns the model properties as a dict"""
+        result = {}
+
+        for attr, _ in six.iteritems(self.openapi_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, "to_dict") else x,
+                    value
+                ))
+            elif hasattr(value, "to_dict"):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], "to_dict") else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        """Returns the string representation of the model"""
+        return pprint.pformat(self.to_dict())
+
+    def __repr__(self):
+        """For `print` and `pprint`"""
+        return self.to_str()
+
+    def __eq__(self, other):
+        """Returns true if both objects are equal"""
+        if not isinstance(other, EnableLiveStreamResponse):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        """Returns true if both objects are not equal"""
+        return not self == other

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ NOTE: This class is auto generated. Do not edit the class manually.
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "mux_python"
-VERSION = "1.8.0"
+VERSION = "1.9.0"
 # To install the library, run the following
 #
 # python setup.py install
@@ -26,7 +26,7 @@ setup(
     description="Official Mux API wrapper for python projects 🐍.",
     author_email="sdks@mux.com",
     url="https://github.com/muxinc/mux-python",
-    download_url="https://github.com/muxinc/mux-python/archive/1.8.0.tar.gz",
+    download_url="https://github.com/muxinc/mux-python/archive/1.9.0.tar.gz",
     keywords=["Mux API", "Video", "Live Stream", "VOD", "Streaming"],
     install_requires=REQUIRES,
     packages=find_packages(),

--- a/test/test_asset_non_standard_input_reasons.py
+++ b/test/test_asset_non_standard_input_reasons.py
@@ -1,0 +1,36 @@
+# coding: utf-8
+
+"""
+Mux Python - Copyright 2019 Mux Inc.
+
+NOTE: This class is auto generated. Do not edit the class manually.
+"""
+
+
+from __future__ import absolute_import
+
+import unittest
+
+import mux_python
+from mux_python.models.asset_non_standard_input_reasons import AssetNonStandardInputReasons  # noqa: E501
+from mux_python.rest import ApiException
+
+
+class TestAssetNonStandardInputReasons(unittest.TestCase):
+    """AssetNonStandardInputReasons unit test stubs"""
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def testAssetNonStandardInputReasons(self):
+        """Test AssetNonStandardInputReasons"""
+        # FIXME: construct object with mandatory attributes with example values
+        # model = mux_python.models.asset_non_standard_input_reasons.AssetNonStandardInputReasons()  # noqa: E501
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_asset_recording_times.py
+++ b/test/test_asset_recording_times.py
@@ -1,0 +1,36 @@
+# coding: utf-8
+
+"""
+Mux Python - Copyright 2019 Mux Inc.
+
+NOTE: This class is auto generated. Do not edit the class manually.
+"""
+
+
+from __future__ import absolute_import
+
+import unittest
+
+import mux_python
+from mux_python.models.asset_recording_times import AssetRecordingTimes  # noqa: E501
+from mux_python.rest import ApiException
+
+
+class TestAssetRecordingTimes(unittest.TestCase):
+    """AssetRecordingTimes unit test stubs"""
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def testAssetRecordingTimes(self):
+        """Test AssetRecordingTimes"""
+        # FIXME: construct object with mandatory attributes with example values
+        # model = mux_python.models.asset_recording_times.AssetRecordingTimes()  # noqa: E501
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_disable_live_stream_response.py
+++ b/test/test_disable_live_stream_response.py
@@ -1,0 +1,36 @@
+# coding: utf-8
+
+"""
+Mux Python - Copyright 2019 Mux Inc.
+
+NOTE: This class is auto generated. Do not edit the class manually.
+"""
+
+
+from __future__ import absolute_import
+
+import unittest
+
+import mux_python
+from mux_python.models.disable_live_stream_response import DisableLiveStreamResponse  # noqa: E501
+from mux_python.rest import ApiException
+
+
+class TestDisableLiveStreamResponse(unittest.TestCase):
+    """DisableLiveStreamResponse unit test stubs"""
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def testDisableLiveStreamResponse(self):
+        """Test DisableLiveStreamResponse"""
+        # FIXME: construct object with mandatory attributes with example values
+        # model = mux_python.models.disable_live_stream_response.DisableLiveStreamResponse()  # noqa: E501
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_enable_live_stream_response.py
+++ b/test/test_enable_live_stream_response.py
@@ -1,0 +1,36 @@
+# coding: utf-8
+
+"""
+Mux Python - Copyright 2019 Mux Inc.
+
+NOTE: This class is auto generated. Do not edit the class manually.
+"""
+
+
+from __future__ import absolute_import
+
+import unittest
+
+import mux_python
+from mux_python.models.enable_live_stream_response import EnableLiveStreamResponse  # noqa: E501
+from mux_python.rest import ApiException
+
+
+class TestEnableLiveStreamResponse(unittest.TestCase):
+    """EnableLiveStreamResponse unit test stubs"""
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def testEnableLiveStreamResponse(self):
+        """Test EnableLiveStreamResponse"""
+        # FIXME: construct object with mandatory attributes with example values
+        # model = mux_python.models.enable_live_stream_response.EnableLiveStreamResponse()  # noqa: E501
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_live_streams_api.py
+++ b/test/test_live_streams_api.py
@@ -67,6 +67,20 @@ class TestLiveStreamsApi(unittest.TestCase):
         """
         pass
 
+    def test_disable_live_stream(self):
+        """Test case for disable_live_stream
+
+        Disable a live stream  # noqa: E501
+        """
+        pass
+
+    def test_enable_live_stream(self):
+        """Test case for enable_live_stream
+
+        Enable a live stream  # noqa: E501
+        """
+        pass
+
     def test_get_live_stream(self):
         """Test case for get_live_stream
 


### PR DESCRIPTION
* Adds support for `recording_times` on Assets created from Live Streams
* Adds support for `non_standard_input_reasons` on Assets
* Adds `enable` and `disable` calls for Live Streams