### PR TITLE
fix(setup.py): pypi metadata

### DIFF
--- a/gen/templates/setup.mustache
+++ b/gen/templates/setup.mustache
@@ -2,6 +2,7 @@
 
 {{>partial_header}}
 
+import os
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "{{{projectName}}}"
@@ -24,21 +25,27 @@ REQUIRES.append("aiohttp >= 3.0.0")
 REQUIRES.append("tornado>=4.2,<5")
 {{/tornado}}
 
+here = os.path.abspath(os.path.dirname(__file__))
+
+def get_file_text(file_name):
+    with open(os.path.join(here, file_name)) as in_file:
+        return in_file.read()
+
 setup(
     name=NAME,
     version=VERSION,
     description="{{appName}}",
     author="{{#infoName}}{{infoName}}{{/infoName}}{{^infoName}}OpenAPI Generator community{{/infoName}}",
     author_email="{{#infoEmail}}{{infoEmail}}{{/infoEmail}}{{^infoEmail}}team@openapitools.org{{/infoEmail}}",
-    url="{{packageUrl}}",
+    url="https://github.com/muxinc/mux-python",
     keywords=["OpenAPI", "OpenAPI-Generator", "{{{appName}}}"],
     install_requires=REQUIRES,
     packages=find_packages(exclude=["test", "tests"]),
     include_package_data=True,
+    long_description=get_file_text("README.md"),
+    long_description_content_type="text/markdown",
     {{#licenseInfo}}license="{{licenseInfo}}",
-    {{/licenseInfo}}long_description="""\
-    {{appDescription}}  # noqa: E501
-    """
+    {{/licenseInfo}}
 )
 {{/-last}}
 {{/apis}}

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@
 """
 
 
+import os
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "mux_python"
@@ -24,18 +25,23 @@ VERSION = "3.7.0"
 
 REQUIRES = ["urllib3 >= 1.25.3", "six >= 1.10", "python-dateutil"]
 
+here = os.path.abspath(os.path.dirname(__file__))
+
+def get_file_text(file_name):
+    with open(os.path.join(here, file_name)) as in_file:
+        return in_file.read()
+
 setup(
     name=NAME,
     version=VERSION,
     description="Mux API",
     author="Mux DevEx",
     author_email="devex@mux.com",
-    url="",
+    url="https://github.com/muxinc/mux-python",
     keywords=["OpenAPI", "OpenAPI-Generator", "Mux API"],
     install_requires=REQUIRES,
     packages=find_packages(exclude=["test", "tests"]),
     include_package_data=True,
-    long_description="""\
-    Mux is how developers build online video. This API encompasses both Mux Video and Mux Data functionality to help you build your video-related projects better and faster than ever before.  # noqa: E501
-    """
+    long_description=get_file_text("README.md"),
+    long_description_content_type="text/markdown",
 )


### PR DESCRIPTION
This updates the setup.py to include some pypi metadata so the the readme and repo url will show up in the sidebar column.

Basically looked at sentry to see what they do: https://github.com/getsentry/sentry-python/blob/master/setup.py


Right now the pypi page looks like:

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/7340772/187012103-a7b4be7f-85ed-4476-b20d-ee7c2269d518.png">
