### PR TITLE
Include MIT license in generation configuration

### DIFF
--- a/gen/generator-config.json
+++ b/gen/generator-config.json
@@ -2,5 +2,6 @@
   "!!source": "https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/python.md",
   "packageName": "mux_python",
   "projectName": "mux_python",
+  "licenseInfo" : "MIT",
   "packageVersion": "3.10.0"
 }


### PR DESCRIPTION
Addresses #64.

Doesn't run a regenerate because we've got one in the pipeline, but I've run a local regeneration, which creates this change in `setup.py`:

```
diff --git a/setup.py b/setup.py
index 13ec39e..1f50724 100644
--- a/setup.py
+++ b/setup.py
@@ -44,4 +44,5 @@ setup(
     include_package_data=True,
     long_description=get_file_text("README.md"),
     long_description_content_type="text/markdown",
+    license="MIT",
 )
```

This will go out in the next release of the Python SDK.