### PR TITLE
Fix HTTPResponse.getheaders() deprecation warning

### DIFF
--- a/gen/templates/rest.mustache
+++ b/gen/templates/rest.mustache
@@ -31,7 +31,7 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""

--- a/mux_python/rest.py
+++ b/mux_python/rest.py
@@ -40,7 +40,7 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""


### PR DESCRIPTION
When using `mux-python` I get this warning:

```python
DeprecationWarning: HTTPResponse.getheaders() is deprecated and will be removed in urllib3 v2.1.0. Instead access HTTPResponse.headers directly.
```

The problem is here at this line: https://github.com/muxinc/mux-python/blob/d896eab0377d8c083589f312e00361a7ce7986f4/mux_python/rest.py#L43

It should be changed to:
```python
return self.urllib3_response.headers
```

This PR fixes https://github.com/muxinc/mux-python/issues/71