### PR TITLE
5.0.1

### DIFF
--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -361,5 +361,4 @@ setup.cfg
 setup.py
 test-requirements.txt
 test/__init__.py
-test/test_asset_metadata.py
 tox.ini

--- a/docs/AssetMetadata.md
+++ b/docs/AssetMetadata.md
@@ -3,9 +3,9 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**title** | **str** | The video title. Max 512 code points. | [optional]
-**creator_id** | **str** | This is an identifier you provide to keep track of the creator of the video. Max 128 code points. | [optional]
-**external_id** | **str** | This is an identifier you provide to link the video to your own data. Max 128 code points. | [optional]
+**title** | **str** | The asset title. Max 512 code points. | [optional]
+**creator_id** | **str** | This is an identifier you provide to keep track of the creator of the asset. Max 128 code points. | [optional]
+**external_id** | **str** | This is an identifier you provide to link the asset to your own data. Max 128 code points. | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/AssetsApi.md
+++ b/docs/AssetsApi.md
@@ -250,7 +250,7 @@ Name | Type | Description  | Notes
 
 Create an asset track
 
-Adds an asset track (for example, subtitles, or an alternate audio track) to an asset.
+Adds an asset track (for example, subtitles, or an alternate audio track) to an asset. Assets must be in the `ready` state before tracks can be added.
 
 ### Example
 

--- a/gen/generator-config.json
+++ b/gen/generator-config.json
@@ -3,5 +3,5 @@
   "packageName": "mux_python",
   "projectName": "mux_python",
   "licenseInfo" : "MIT",
-  "packageVersion": "5.0.0"
+  "packageVersion": "5.0.1"
 }

--- a/mux_python/__init__.py
+++ b/mux_python/__init__.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 
-__version__ = "5.0.0"
+__version__ = "5.0.1"
 
 # import apis into sdk package
 from mux_python.api.assets_api import AssetsApi

--- a/mux_python/api/assets_api.py
+++ b/mux_python/api/assets_api.py
@@ -479,7 +479,7 @@ class AssetsApi(object):
     def create_asset_track(self, asset_id, create_track_request, **kwargs):  # noqa: E501
         """Create an asset track  # noqa: E501
 
-        Adds an asset track (for example, subtitles, or an alternate audio track) to an asset.  # noqa: E501
+        Adds an asset track (for example, subtitles, or an alternate audio track) to an asset. Assets must be in the `ready` state before tracks can be added.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -511,7 +511,7 @@ class AssetsApi(object):
     def create_asset_track_with_http_info(self, asset_id, create_track_request, **kwargs):  # noqa: E501
         """Create an asset track  # noqa: E501
 
-        Adds an asset track (for example, subtitles, or an alternate audio track) to an asset.  # noqa: E501
+        Adds an asset track (for example, subtitles, or an alternate audio track) to an asset. Assets must be in the `ready` state before tracks can be added.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 

--- a/mux_python/api_client.py
+++ b/mux_python/api_client.py
@@ -79,7 +79,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'Mux Python | 5.0.0'
+        self.user_agent = 'Mux Python | 5.0.1'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/mux_python/configuration.py
+++ b/mux_python/configuration.py
@@ -406,7 +406,7 @@ conf = mux_python.Configuration(
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: v1\n"\
-               "SDK Package Version: 5.0.0".\
+               "SDK Package Version: 5.0.1".\
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self):

--- a/mux_python/models/asset_metadata.py
+++ b/mux_python/models/asset_metadata.py
@@ -70,7 +70,7 @@ class AssetMetadata(object):
     def title(self):
         """Gets the title of this AssetMetadata.  # noqa: E501
 
-        The video title. Max 512 code points.  # noqa: E501
+        The asset title. Max 512 code points.  # noqa: E501
 
         :return: The title of this AssetMetadata.  # noqa: E501
         :rtype: str
@@ -81,7 +81,7 @@ class AssetMetadata(object):
     def title(self, title):
         """Sets the title of this AssetMetadata.
 
-        The video title. Max 512 code points.  # noqa: E501
+        The asset title. Max 512 code points.  # noqa: E501
 
         :param title: The title of this AssetMetadata.  # noqa: E501
         :type title: str
@@ -96,7 +96,7 @@ class AssetMetadata(object):
     def creator_id(self):
         """Gets the creator_id of this AssetMetadata.  # noqa: E501
 
-        This is an identifier you provide to keep track of the creator of the video. Max 128 code points.  # noqa: E501
+        This is an identifier you provide to keep track of the creator of the asset. Max 128 code points.  # noqa: E501
 
         :return: The creator_id of this AssetMetadata.  # noqa: E501
         :rtype: str
@@ -107,7 +107,7 @@ class AssetMetadata(object):
     def creator_id(self, creator_id):
         """Sets the creator_id of this AssetMetadata.
 
-        This is an identifier you provide to keep track of the creator of the video. Max 128 code points.  # noqa: E501
+        This is an identifier you provide to keep track of the creator of the asset. Max 128 code points.  # noqa: E501
 
         :param creator_id: The creator_id of this AssetMetadata.  # noqa: E501
         :type creator_id: str
@@ -122,7 +122,7 @@ class AssetMetadata(object):
     def external_id(self):
         """Gets the external_id of this AssetMetadata.  # noqa: E501
 
-        This is an identifier you provide to link the video to your own data. Max 128 code points.  # noqa: E501
+        This is an identifier you provide to link the asset to your own data. Max 128 code points.  # noqa: E501
 
         :return: The external_id of this AssetMetadata.  # noqa: E501
         :rtype: str
@@ -133,7 +133,7 @@ class AssetMetadata(object):
     def external_id(self, external_id):
         """Sets the external_id of this AssetMetadata.
 
-        This is an identifier you provide to link the video to your own data. Max 128 code points.  # noqa: E501
+        This is an identifier you provide to link the asset to your own data. Max 128 code points.  # noqa: E501
 
         :param external_id: The external_id of this AssetMetadata.  # noqa: E501
         :type external_id: str

--- a/mux_python/models/static_rendition.py
+++ b/mux_python/models/static_rendition.py
@@ -339,7 +339,7 @@ class StaticRendition(object):
         :param resolution_tier: The resolution_tier of this StaticRendition.  # noqa: E501
         :type resolution_tier: str
         """
-        allowed_values = ["2160p", "1440p", "1080p", "720p"]  # noqa: E501
+        allowed_values = ["2160p", "1440p", "1080p", "720p", "audio-only"]  # noqa: E501
         if self.local_vars_configuration.client_side_validation and resolution_tier not in allowed_values:  # noqa: E501
             raise ValueError(
                 "Invalid value for `resolution_tier` ({0}), must be one of {1}"  # noqa: E501

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import os
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "mux_python"
-VERSION = "5.0.0"
+VERSION = "5.0.1"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
- fix: add `audio-only` enum option in `resolution_tier` for Static Rendition responses