### PR TITLE
Update deprecated getheader method for urllib3

### DIFF
--- a/gen/generator-config.json
+++ b/gen/generator-config.json
@@ -3,5 +3,5 @@
   "packageName": "mux_python",
   "projectName": "mux_python",
   "licenseInfo" : "MIT",
-  "packageVersion": "5.1.0"
+  "packageVersion": "5.1.1"
 }

--- a/gen/templates/rest.mustache
+++ b/gen/templates/rest.mustache
@@ -35,7 +35,7 @@ class RESTResponse(io.IOBase):
 
     def getheader(self, name, default=None):
         """Returns a given response header."""
-        return self.urllib3_response.getheader(name, default)
+        return self.urllib3_response.headers.get(name, default)
 
 
 class RESTClientObject(object):

--- a/mux_python/__init__.py
+++ b/mux_python/__init__.py
@@ -15,7 +15,7 @@
 
 from __future__ import absolute_import
 
-__version__ = "5.1.0"
+__version__ = "5.1.1"
 
 # import apis into sdk package
 from mux_python.api.annotations_api import AnnotationsApi

--- a/mux_python/api_client.py
+++ b/mux_python/api_client.py
@@ -79,7 +79,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'Mux Python | 5.1.0'
+        self.user_agent = 'Mux Python | 5.1.1'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/mux_python/configuration.py
+++ b/mux_python/configuration.py
@@ -406,7 +406,7 @@ conf = mux_python.Configuration(
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: v1\n"\
-               "SDK Package Version: 5.1.0".\
+               "SDK Package Version: 5.1.1".\
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self):

--- a/mux_python/rest.py
+++ b/mux_python/rest.py
@@ -44,7 +44,7 @@ class RESTResponse(io.IOBase):
 
     def getheader(self, name, default=None):
         """Returns a given response header."""
-        return self.urllib3_response.getheader(name, default)
+        return self.urllib3_response.headers.get(name, default)
 
 
 class RESTClientObject(object):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import os
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "mux_python"
-VERSION = "5.1.0"
+VERSION = "5.1.1"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
Adding the single header case mentioned in issue #83 that shifts from `urllib3_response.getheader(name, default)` to `urllib3_response.headers.get(name, default)` instead.

Followed similar structure as #72 and #73 pull requests that covered the multi-header case already.

Raises the patch version to v5.1.1.